### PR TITLE
Chat: Fix index out of bounds crash in case verb_pos equals zero

### DIFF
--- a/src/strategy/actions/SayAction.cpp
+++ b/src/strategy/actions/SayAction.cpp
@@ -969,7 +969,7 @@ std::string ChatReplyAction::GenerateReplyMessage(Player* bot, std::string& inco
                 msg = "ya %s but thats in the past";
                 break;
             case 2:
-                msg = word[verb_pos - 1] + " will " + word[verb_pos + 1] + " again though %s";
+                msg = word[verb_pos ? verb_pos - 1 : verb_pos + 1] + " will " + word[verb_pos + 1] + " again though %s";
                 break;
             }
             msg = std::regex_replace(msg, std::regex("%s"), name);
@@ -1013,7 +1013,7 @@ std::string ChatReplyAction::GenerateReplyMessage(Player* bot, std::string& inco
                 msg = "%s, what will happen %s?";
                 break;
             case 2:
-                msg = "are you saying " + word[verb_pos - 1] + " will " + word[verb_pos + 1] + " " + word[verb_pos + 2] + " %s?";
+                msg = "are you saying " + word[verb_pos ? verb_pos - 1 : verb_pos + 1] + " will " + word[verb_pos + 1] + " " + word[verb_pos + 2] + " %s?";
                 break;
             }
             msg = std::regex_replace(msg, std::regex("%s"), name);


### PR DESCRIPTION
Prevents invalid accesses to the word[] array, preventing possible crashes.

Improves the message selection logic in bot chat.

Fixes an error in the switch-case structure, ensuring that all possible messages are used correctly.