### PR TITLE
Introduction of the SafeLearn(spellId) lambda that checks if the bot …

### DIFF
--- a/src/factory/PlayerbotFactory.cpp
+++ b/src/factory/PlayerbotFactory.cpp
@@ -2201,14 +2201,20 @@ void PlayerbotFactory::InitSkills()
     bot->UpdateSkillsForLevel();
 
     bot->SetSkill(SKILL_RIDING, 0, 0, 0);
+    auto SafeLearn = [this](uint32 spellId)
+    {
+        if (!bot->HasSpell(spellId))
+            bot->learnSpell(spellId);
+    };
+
     if (bot->GetLevel() >= sPlayerbotAIConfig->useGroundMountAtMinLevel)
-        bot->learnSpell(33388);
+        SafeLearn(33388);
     if (bot->GetLevel() >= sPlayerbotAIConfig->useFastGroundMountAtMinLevel)
-        bot->learnSpell(33391);
+        SafeLearn(33391);
     if (bot->GetLevel() >= sPlayerbotAIConfig->useFlyMountAtMinLevel)
-        bot->learnSpell(34090);
+        SafeLearn(34090);
     if (bot->GetLevel() >= sPlayerbotAIConfig->useFastFlyMountAtMinLevel)
-        bot->learnSpell(34091);
+        SafeLearn(34091);
 
     uint32 skillLevel = bot->GetLevel() < 40 ? 0 : 1;
     uint32 dualWieldLevel = bot->GetLevel() < 20 ? 0 : 1;


### PR DESCRIPTION
…already knows the spell before learning it.

This PR adds a safety check to the mount skill learning process in PlayerbotFactory::InitSkills, using a SafeLearn lambda to prevent the bot from trying to learn spells it already has. This fixes error messages like Duplicate entry when using the .bot init command.